### PR TITLE
Add library build

### DIFF
--- a/.build/index.js
+++ b/.build/index.js
@@ -1,0 +1,17 @@
+/* This exposes files and components for the build process and bundles them up to the /dist folder. */
+
+/**
+ * CSS Imports
+ * Packages any provided CSS files to the dist style file.
+ */
+import '@Css/core.scss'
+
+/**
+ * Component Imports
+ * Packages any provided components to the dist module file.
+ */
+import HelloWorld from '@Components/HelloWorld.vue'
+
+export {
+    HelloWorld
+}

--- a/.build/index.js
+++ b/.build/index.js
@@ -8,10 +8,14 @@ import '@Css/core.scss'
 
 /**
  * Component Imports
- * Packages any provided components to the dist module file.
+ * Automatically imports all .vue components in the @Components directory, and
+ * then compiles them into an export list for use.
  */
-import HelloWorld from '@Components/HelloWorld.vue'
+const components = import.meta.glob('@Components/**/*.vue', { eager: true })
+const componentsExport = Object.entries(components).reduce((acc, [path, module]) => {
+    const componentName = path.split('/').pop().replace('.vue', '');
+    acc[componentName] = module.default;
+    return acc;
+}, {});
 
-export {
-    HelloWorld
-}
+export default { ...componentsExport }

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -19,6 +19,7 @@ module.exports = {
         node: true
     },
     rules: {
+        'vue/multi-word-component-names': 0,
         eqeqeq: ['error', 'always'],
         'vue/eqeqeq': ['error', 'always'],
         'no-unused-vars':

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -100,7 +100,7 @@ module.exports = {
 
     overrides: [
         {
-            files: ['*.stories.js'],
+            files: ['*.stories.js', '*.config.js'],
             rules: {
                 'jsdoc/require-jsdoc': 'off'
             }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,16 @@
         "node": ">=0.20.0"
     },
     "type": "module",
+    "files": ["dist"],
+    "main": "./dist/ocelot-ui.umd.js",
+    "module": "./dist/ocelot-ui.es.js",
+    "exports": {
+        ".": {
+            "import": "./dist/ocelot-ui.es.js",
+            "require": "./dist/ocelot-ui.umd.js"
+        },
+        "./dist/style.css": "./dist/style.css"
+    },
     "scripts": {
         "dev": "vite",
         "build": "vite build",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { fileURLToPath, URL } from 'node:url'
-
 import { defineConfig } from 'vite'
+import path from 'path'
 import vue from '@vitejs/plugin-vue'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
@@ -10,7 +10,27 @@ export default defineConfig({
     resolve: {
         alias: {
             '@': fileURLToPath(new URL('./src', import.meta.url)),
-            '@Css': fileURLToPath(new URL('./src/css', import.meta.url))
+            '@Css': fileURLToPath(new URL('./src/css', import.meta.url)),
+            '@Components': fileURLToPath(
+                new URL('./src/components', import.meta.url)
+            )
+        }
+    },
+
+    // Library build mode to package distribution files.
+    build: {
+        lib: {
+            entry: path.resolve(__dirname, '.build/index.js'),
+            name: 'ocelot-ui',
+            fileName: (format) => `ocelot-ui.${format}.js`
+        },
+        rollupOptions: {
+            external: ['vue'],
+            output: {
+                globals: {
+                    vue: 'Vue'
+                }
+            }
         }
     }
 })


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes made in this pull request. Ie:
- What issue does this PR address? (e.g., Fixes #123)
- What functionality does this PR add or modify?
- Why is this change necessary?
-->
Adds a library mode build process to create the necessary module files to install OcelotUI.

## Changes
<!-- Provide a detail list of changes, this section should be understandable enough that someone could use it to recreate this PR manually. -->

- Sets library build mode in Vite
- Create initial .build/index.js file to define exports
- Add stylesheet to the export
- Disable ESLint multi-name
- Add automation script to compile all components for export

## Visual Changes
<!-- Provide any relevant before and after screenshots for each significant change. -->
![image](https://github.com/user-attachments/assets/fe928cb0-0a96-49b8-bb0d-7b64c53de314)


## Testing
<!-- Detail the steps required to test, including any prerequisites, commands, and instructions. Ie:
1. Run `npm install && npm run storybook`
2. Go to the Button story
3. Test that the button is clickable
-->

1. Run `npm i && npm run build`

## Additional Information
<!-- Add any other context or information that reviewers should be aware of. -->

## Checklist

**Please ensure all of the following tasks are completed:**

-   [ ] My code follows the style guidelines of this project.
-   [ ] I have performed a self-review of my code.
-   [ ] I have made corresponding changes to the documentation.
-   [ ] I have updated the stories for components added or changed in this PR.
-   [ ] My changes generate no new warnings.
-   [ ] I have added tests that prove my fix is effective or that my feature works.
-   [ ] New and existing unit tests pass locally with my changes.
