### PR TITLE
Test Build

### DIFF
--- a/.storybook/test-runner.js
+++ b/.storybook/test-runner.js
@@ -1,5 +1,7 @@
 const { injectAxe, checkA11y } = require('axe-playwright')
 
+let isAxeRunning = false
+
 /*
  * See https://storybook.js.org/docs/writing-tests/test-runner#test-hook-api
  * to learn more about the test-runner hooks API.
@@ -9,19 +11,32 @@ module.exports = {
         await injectAxe(page)
     },
     async postVisit(page) {
-        await checkA11y(
-            page,
-            '#storybook-root',
-            {
-                detailedReport: true,
-                detailedReportOptions: {
-                    html: true
+        while (isAxeRunning) {
+            await new Promise((resolve) => setTimeout(resolve, 50)) // Wait until the previous Axe run finishes
+        }
+        isAxeRunning = true
+        try {
+            await checkA11y(
+                page,
+                '#storybook-root',
+                {
+                    detailedReport: true,
+                    detailedReportOptions: {
+                        html: true
+                    },
+                    includedImpacts: [
+                        'minor',
+                        'moderate',
+                        'serious',
+                        'critical'
+                    ],
+                    verbose: false
                 },
-                includedImpacts: ['minor', 'moderate', 'serious', 'critical'],
-                verbose: false
-            },
-            false,
-            'v2'
-        )
+                false,
+                'v2'
+            )
+        } finally {
+            isAxeRunning = false
+        }
     }
 }

--- a/src/stories/components/Button.stories.js
+++ b/src/stories/components/Button.stories.js
@@ -50,26 +50,31 @@ export default {
         `
     })
 }
+
 export const Primary = {
     args: {
         type: 'primary'
     }
 }
+
 export const Secondary = {
     args: {
         type: 'secondary'
     }
 }
+
 export const Tertiary = {
     args: {
         type: 'tertiary'
     }
 }
+
 export const Text = {
     args: {
         type: 'text'
     }
 }
+
 export const None = {
     args: {
         type: 'none'


### PR DESCRIPTION
Storybook tests are failing in the CI for:

> page.evaluate: Error: Axe is already running. Use await axe.run() to wait for the previous run to finish before starting a new run.

I'm unsure why, I can only assume a recent Storybook change has caused this. To resolve for now I've added some code to ensure they're ran sequentially, which seems to pass.