### PR TITLE
Refactor image component

### DIFF
--- a/src/components/Image.vue
+++ b/src/components/Image.vue
@@ -1,76 +1,171 @@
 <template>
-    <img
-        v-if="isLoaded"
-        :alt="alt"
-        :height="height"
-        :sizes="sizes"
-        :src="src"
-        :srcset="srcset"
-        :width="width"
-    />
-
     <div
-        v-else
-        class="flex items-center justify-center text-gray-300 bg-gray-100 rounded-lg"
-        :class="{ 'animate-pulse': !isFailed }"
-        :style="{
-            height: height ? `${height}` : '100%',
-            width: width ? `${width}` : '100%'
-        }"
+        class="relative overflow-hidden"
+        :class="!hasSize ? 'min-h-16' : ''"
+        :style="containerStyle"
     >
-        <Icon
-            class="w-1/2 h-1/2"
-            :icon="isFailed ? 'PhotoOff' : 'Photo'"
+        <!-- Skeleton shown while loading -->
+        <div
+            v-if="state === 'loading'"
+            aria-hidden="true"
+            class="absolute inset-0 flex items-center justify-center bg-gray-100 dark:bg-gray-800 animate-pulse"
+        >
+            <Icon
+                class="w-1/4 h-1/4 max-w-12 max-h-12 text-gray-300 dark:text-gray-600"
+                icon="Photo"
+            />
+        </div>
+
+        <!-- Error state -->
+        <div
+            v-else-if="state === 'error'"
+            class="absolute inset-0 flex items-center justify-center bg-gray-50 dark:bg-gray-900"
+            role="img"
+            :aria-label="alt"
+        >
+            <Icon
+                class="w-1/4 h-1/4 max-w-12 max-h-12 text-gray-400 dark:text-gray-500"
+                icon="PhotoOff"
+            />
+        </div>
+
+        <!-- LQIP blur-up: fades out as main image fades in -->
+        <img
+            v-if="placeholder"
+            alt=""
+            aria-hidden="true"
+            class="absolute inset-0 w-full h-full transition-opacity duration-500 pointer-events-none select-none"
+            :class="[fitClass, state === 'loaded' ? 'opacity-0' : 'opacity-100 blur-sm scale-105']"
+            :src="placeholder"
+            :style="objectPositionStyle"
+        />
+
+        <!-- Main image — opacity-0 until loaded, then fades in -->
+        <img
+            v-if="state !== 'error'"
+            v-bind="$attrs"
+            class="absolute inset-0 w-full h-full transition-opacity duration-500"
+            :alt="alt"
+            :class="[fitClass, state === 'loaded' ? 'opacity-100' : 'opacity-0']"
+            :decoding="decoding"
+            :fetchpriority="fetchpriority"
+            :height="numericHeight"
+            :loading="loading"
+            :sizes="sizes || undefined"
+            :src="src"
+            :srcset="srcset || undefined"
+            :style="objectPositionStyle"
+            :width="numericWidth"
+            @error="onError"
+            @load="onLoad"
         />
     </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue'
+import { ref, computed, watch } from 'vue'
 import Icon from '@/components/Icon.vue'
 
+defineOptions({ inheritAttrs: false })
+
+type ImageState = 'loading' | 'loaded' | 'error'
+
 interface Props {
+    /** Alt text — required for accessibility */
     alt: string
-    height?: string | null
-    sizes?: string
+    /** Image source URL */
     src: string
+    /** Fixed width (number = px, string = any CSS unit) */
+    width?: string | number | null
+    /** Fixed height (number = px, string = any CSS unit) */
+    height?: string | number | null
+    /** CSS aspect-ratio value, e.g. "16/9" or "4/3" */
+    aspectRatio?: string
+    /** Responsive sizes attribute */
+    sizes?: string
+    /** Responsive srcset attribute */
     srcset?: string
-    width?: string | null
+    /** Native loading strategy */
+    loading?: 'lazy' | 'eager'
+    /** Image decoding hint */
+    decoding?: 'auto' | 'async' | 'sync'
+    /** Fetch priority hint */
+    fetchpriority?: 'high' | 'low' | 'auto'
+    /** CSS object-fit value */
+    fit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down'
+    /** CSS object-position value, e.g. "center", "top left" */
+    position?: string
+    /** Low-quality placeholder URL or data URI for blur-up effect */
+    placeholder?: string
 }
 
-/**
- * Props for the image component.
- * - `src` and `alt` are required.
- * - `srcset`, `sizes`, `width`, and `height` are optional for responsive/fixed rendering.
- */
 const props = withDefaults(defineProps<Props>(), {
+    width: null,
     height: null,
+    aspectRatio: '',
     sizes: '',
     srcset: '',
-    width: null
+    loading: 'lazy',
+    decoding: 'async',
+    fetchpriority: 'auto',
+    fit: 'cover',
+    position: 'center',
+    placeholder: ''
 })
 
-/**
- * Tracks whether the image has successfully loaded or failed.
- */
-const isLoaded = ref(false)
-const isFailed = ref(false)
+const state = ref<ImageState>('loading')
 
-/**
- * Loads the image manually using the native Image API.
- */
-const loadImage = () => {
-    isLoaded.value = isFailed.value = false
+const onLoad = () => { state.value = 'loaded' }
+const onError = () => { state.value = 'error' }
 
-    const img = new Image()
-    img.src = props.src
-    if (props.srcset) img.srcset = props.srcset
-    if (props.sizes) img.sizes = props.sizes
+watch(() => props.src, () => { state.value = 'loading' })
 
-    img.onload = () => (isLoaded.value = true)
-    img.onerror = () => (isLoaded.value = isFailed.value = true)
+/** Pixel value for the HTML width attribute (improves CLS) */
+const numericWidth = computed((): number | undefined => {
+    if (!props.width) return undefined
+    const n = parseInt(String(props.width))
+    return isNaN(n) ? undefined : n
+})
+
+/** Pixel value for the HTML height attribute (improves CLS) */
+const numericHeight = computed((): number | undefined => {
+    if (!props.height) return undefined
+    const n = parseInt(String(props.height))
+    return isNaN(n) ? undefined : n
+})
+
+/** Whether any explicit sizing is provided — used to add min-h fallback for skeleton */
+const hasSize = computed(() => !!(props.width || props.height || props.aspectRatio))
+
+/** Ensures a value like "400" becomes "400px"; "100%" or "auto" are passed through unchanged */
+const toCssSize = (val: string | number): string => {
+    if (typeof val === 'number') return `${val}px`
+    return /^\d+(\.\d+)?$/.test(val.trim()) ? `${val}px` : val
 }
 
-onMounted(loadImage)
-watch(() => props.src, loadImage)
+const containerStyle = computed((): Record<string, string> => {
+    const style: Record<string, string> = {}
+
+    style.width = props.width ? toCssSize(props.width) : '100%'
+
+    if (props.aspectRatio) {
+        style['aspect-ratio'] = props.aspectRatio
+    } else if (props.height) {
+        style.height = toCssSize(props.height)
+    }
+
+    return style
+})
+
+const fitClassMap: Record<NonNullable<Props['fit']>, string> = {
+    cover: 'object-cover',
+    contain: 'object-contain',
+    fill: 'object-fill',
+    none: 'object-none',
+    'scale-down': 'object-scale-down'
+}
+
+const fitClass = computed(() => fitClassMap[props.fit ?? 'cover'])
+
+const objectPositionStyle = computed(() => ({ 'object-position': props.position }))
 </script>

--- a/src/stories/components/Image.stories.ts
+++ b/src/stories/components/Image.stories.ts
@@ -10,37 +10,72 @@ const meta: Meta<typeof Image> = {
     argTypes: {
         alt: {
             control: 'text',
-            description: 'Alt text for the image (required)'
+            description: 'Alt text for the image (required for accessibility)'
+        },
+        aspectRatio: {
+            control: 'text',
+            description: 'CSS aspect-ratio value, e.g. "16/9" or "4/3"'
+        },
+        decoding: {
+            control: 'select',
+            options: ['auto', 'async', 'sync'],
+            description: 'Image decoding hint'
+        },
+        fetchpriority: {
+            control: 'select',
+            options: ['auto', 'high', 'low'],
+            description: 'Fetch priority hint — use "high" for LCP images above the fold'
+        },
+        fit: {
+            control: 'select',
+            options: ['cover', 'contain', 'fill', 'none', 'scale-down'],
+            description: 'CSS object-fit value'
         },
         height: {
-            control: 'String',
-            description: 'Height of the image with sizing qualifier, ie px or %'
+            control: 'text',
+            description: 'Fixed height (number = px, or any CSS unit string)'
+        },
+        loading: {
+            control: 'select',
+            options: ['lazy', 'eager'],
+            description: 'Native loading strategy — use "eager" for above-the-fold images'
+        },
+        placeholder: {
+            control: 'text',
+            description: 'Low-quality placeholder URL or data URI for blur-up effect'
+        },
+        position: {
+            control: 'text',
+            description: 'CSS object-position value, e.g. "center", "top left"'
         },
         sizes: {
             control: 'text',
-            description: 'Optional image sizes attribute'
+            description: 'Responsive sizes attribute'
         },
         src: {
             control: 'text',
-            description: 'Source URL for the image (required)'
+            description: 'Image source URL (required)'
         },
         srcset: {
             control: 'text',
-            description: 'Optional responsive image `srcset`'
+            description: 'Responsive srcset attribute'
         },
         width: {
-            control: 'number',
-            description: 'Width of the image with sizing qualifier, ie px or %'
+            control: 'text',
+            description: 'Fixed width (number = px, or any CSS unit string)'
         }
     },
 
     args: {
         alt: faker.lorem.words(3),
-        src: faker.image.url({ width: 300, height: 200 }),
-        srcset: '',
-        sizes: '',
-        width: '300px',
-        height: '200px'
+        src: faker.image.url({ width: 400, height: 300 }),
+        width: '400',
+        height: '300',
+        fit: 'cover',
+        position: 'center',
+        loading: 'lazy',
+        decoding: 'async',
+        fetchpriority: 'auto'
     },
 
     render: (args) => ({
@@ -49,16 +84,21 @@ const meta: Meta<typeof Image> = {
             return { args }
         },
         template: `
-            <div class="max-w-full">
-                <Image
-                    :alt="args.alt"
-                    :src="args.src"
-                    :srcset="args.srcset"
-                    :sizes="args.sizes"
-                    :width="args.width"
-                    :height="args.height"
-                />
-            </div>
+            <Image
+                :alt="args.alt"
+                :aspect-ratio="args.aspectRatio"
+                :decoding="args.decoding"
+                :fetchpriority="args.fetchpriority"
+                :fit="args.fit"
+                :height="args.height"
+                :loading="args.loading"
+                :placeholder="args.placeholder"
+                :position="args.position"
+                :sizes="args.sizes"
+                :src="args.src"
+                :srcset="args.srcset"
+                :width="args.width"
+            />
         `
     })
 }
@@ -66,23 +106,49 @@ const meta: Meta<typeof Image> = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {
-    play: async ({ canvasElement }) => {
-        // The component calls loadImage() in onMounted before the play function runs,
-        // so we just wait for it to resolve (load or error) rather than mocking Image.
-        await waitFor(
-            () => {
-                // Either an <img> (loaded) or a non-pulsing placeholder (error state) should appear
-                const img = canvasElement.querySelector('img')
-                const failed = canvasElement.querySelector('div:not(.animate-pulse) svg')
-                if (!img && !failed) throw new Error('Image not yet resolved')
-            },
-            { timeout: 10000 }
-        )
-    }
+const waitForImage = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    await waitFor(
+        () => {
+            const img = canvasElement.querySelector('img:not([aria-hidden])')
+            const error = canvasElement.querySelector('[role="img"]')
+            if (!img && !error) throw new Error('Image not yet resolved')
+        },
+        { timeout: 10000 }
+    )
 }
 
-export const WithSrcset: Story = {
+export const Default: Story = {
+    play: waitForImage
+}
+
+export const AspectRatio: Story = {
+    args: {
+        src: faker.image.url({ width: 800, height: 450 }),
+        width: '100%',
+        height: undefined,
+        aspectRatio: '16/9'
+    },
+    render: (args) => ({
+        components: { Image },
+        setup() {
+            return { args }
+        },
+        template: `
+            <div class="w-96">
+                <Image
+                    :alt="args.alt"
+                    :aspect-ratio="args.aspectRatio"
+                    :fit="args.fit"
+                    :src="args.src"
+                    :width="args.width"
+                />
+            </div>
+        `
+    }),
+    play: waitForImage
+}
+
+export const Responsive: Story = {
     args: {
         src: faker.image.url({ width: 900, height: 600 }),
         srcset: `
@@ -91,7 +157,44 @@ export const WithSrcset: Story = {
             ${faker.image.url({ width: 900, height: 600 })} 900w
         `,
         sizes: '(max-width: 600px) 300px, (max-width: 900px) 600px, 900px',
-        width: '900px',
-        height: '600px'
+        width: '900',
+        height: '600'
+    },
+    play: waitForImage
+}
+
+export const ObjectFitContain: Story = {
+    args: {
+        src: faker.image.url({ width: 600, height: 200 }),
+        fit: 'contain',
+        width: '400',
+        height: '300'
+    },
+    play: waitForImage
+}
+
+export const EagerHighPriority: Story = {
+    args: {
+        src: faker.image.url({ width: 400, height: 300 }),
+        loading: 'eager',
+        fetchpriority: 'high'
+    },
+    play: waitForImage
+}
+
+export const ErrorState: Story = {
+    args: {
+        src: 'https://example.invalid/broken-image.jpg',
+        width: '400',
+        height: '300'
+    },
+    play: async ({ canvasElement }) => {
+        await waitFor(
+            () => {
+                const error = canvasElement.querySelector('[role="img"]')
+                if (!error) throw new Error('Error state not shown')
+            },
+            { timeout: 10000 }
+        )
     }
 }


### PR DESCRIPTION
The existing Image component had a minimal implementation — a JS-preloaded <img> with a basic skeleton fallback. This replaces
   it with a more complete, accessible component covering the same ground as Nuxt Image.                                        
                                                            
  Changes

  Image.vue — full rewrite
  - Replaced manual new Image() preload approach with native <img> @load/@error events and v-if state management (loading →
  loaded | error)
  - Added loading="lazy" (default), decoding="async", and fetchpriority props — all pass through to the native <img> element
  - Added fit prop (object-fit) and position prop (object-position) for layout control
  - Added aspectRatio prop for responsive containers without fixed height
  - Added placeholder prop — accepts a data URI or URL for a blur-up LQIP effect; fades out as the main image fades in
  - Skeleton and error states are now separate blocks with distinct styling — error renders a PhotoOff icon with role="img" and
  aria-label for screen readers
  - Fixed CSS unit bug: bare numeric strings like "400" are now normalised to "400px" in container styles
  - inheritAttrs: false — extra attributes (classes, data attributes, etc.) pass through to the <img> element, not the wrapper
  div

  Image.stories.ts
  - Updated arg types to cover all new props
  - Added stories: AspectRatio, Responsive, ObjectFitContain, EagerHighPriority, ErrorState
