### PR TITLE
Create a toast component

### DIFF
--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -1,0 +1,209 @@
+<template>
+    <Teleport to="#portal-target">
+        <div
+            aria-label="Notifications"
+            :class="containerClass"
+        >
+            <!-- sr-only live regions for screen reader announcements -->
+            <div
+                aria-atomic="true"
+                aria-live="polite"
+                class="sr-only"
+            >
+                {{ politeMsg }}
+            </div>
+
+            <div
+                aria-atomic="true"
+                aria-live="assertive"
+                class="sr-only"
+            >
+                {{ assertiveMsg }}
+            </div>
+
+            <!-- Toast stack — scrollable when expanded, overflow-x-hidden contains slide transitions -->
+            <div
+                class="overflow-x-hidden"
+                :class="{ 'flex-1 overflow-y-auto min-h-0': isExpanded }"
+            >
+                <TransitionGroup
+                    class="relative flex flex-col gap-2"
+                    tag="div"
+                    :name="transitionName"
+                >
+                    <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -->
+                    <div
+                        v-for="toast in visibleToasts"
+                        :key="toast.id"
+                        class="flex items-start gap-3 rounded-xl p-4 shadow border"
+                        :class="[typeBorder[toast.type], typeBg[toast.type]]"
+                        :role="toast.type === 'error' ? 'alert' : 'status'"
+                        @focusin="!toast.permanent && pauseTimer(toast.id)"
+                        @focusout="!toast.permanent && resumeTimer(toast.id, toast.duration)"
+                        @mouseenter="!toast.permanent && pauseTimer(toast.id)"
+                        @mouseleave="!toast.permanent && resumeTimer(toast.id, toast.duration)"
+                    >
+                        <Icon
+                            aria-hidden="true"
+                            class="py-2"
+                            size="xl"
+                            :class="typeIconColor[toast.type]"
+                            :icon="typeIcon[toast.type]"
+                        />
+
+                        <p class="flex-1 my-2 min-w-0 text-sm font-medium text-black dark:text-white">
+                            {{ toast.message }}
+                        </p>
+
+                        <Button
+                            aria-label="Dismiss notification"
+                            class="shrink-0"
+                            type="tertiary"
+                            @click="remove(toast.id)"
+                        >
+                            <Icon
+                                aria-hidden="true"
+                                icon="X"
+                                size="base"
+                            />
+                        </Button>
+                    </div>
+                </TransitionGroup>
+            </div>
+
+            <!-- Unified control bar — no transition, content switches in place -->
+            <div
+                v-if="toasts.length > MAX_VISIBLE"
+                class="shrink-0 flex items-center justify-between rounded-xl px-4 py-2 shadow border bg-white dark:bg-gray-900 text-sm"
+                :class="typeBorder.default"
+            >
+                <template v-if="!isExpanded">
+                    <span class="text-black dark:text-white">
+                        {{ hiddenCount }} more notification{{ hiddenCount === 1 ? '' : 's' }}
+                    </span>
+                    <div class="flex">
+                        <Button
+                            size="small"
+                            type="text"
+                            @click="isExpanded = true"
+                        >
+                            Show all
+                        </Button>
+
+                        <Button
+                            size="small"
+                            type="text"
+                            @click="clear()"
+                        >
+                            Dismiss all
+                        </Button>
+                    </div>
+                </template>
+
+                <template v-else>
+                    <Button
+                        class="ml-auto"
+                        size="small"
+                        type="text"
+                        @click="isExpanded = false"
+                    >
+                        Show less
+                    </Button>
+                </template>
+            </div>
+        </div>
+    </Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, nextTick } from 'vue'
+import Icon from '@Components/Icon.vue'
+import Button from '@Components/Button.vue'
+import { useToast } from '@Composables/useToast'
+import type { ToastType } from '@Composables/useToast'
+
+type Placement = 'top-right' | 'top-left' | 'bottom-right' | 'bottom-left'
+
+const props = withDefaults(defineProps<{
+    placement?: Placement
+}>(), {
+    placement: 'top-right'
+})
+
+const { toasts, remove, clear, pauseTimer, resumeTimer } = useToast()
+
+const MAX_VISIBLE = 5
+const isExpanded = ref(false)
+
+const isBottom = computed(() => props.placement.startsWith('bottom'))
+const isRight = computed(() => props.placement.endsWith('right'))
+
+const orderedToasts = computed(() =>
+    isBottom.value ? [...toasts].reverse() : [...toasts]
+)
+
+const visibleToasts = computed(() =>
+    isExpanded.value ? orderedToasts.value : orderedToasts.value.slice(0, MAX_VISIBLE)
+)
+
+const hiddenCount = computed(() => Math.max(0, toasts.length - MAX_VISIBLE))
+
+const containerClass = computed(() => [
+    'fixed z-100 flex gap-2 min-w-80 max-w-[calc(100vw-2rem)]',
+    isBottom.value ? 'flex-col-reverse' : 'flex-col',
+    isBottom.value ? 'bottom-4' : 'top-4',
+    isRight.value ? 'right-4' : 'left-4',
+    isExpanded.value ? 'max-h-[calc(100vh-2rem)]' : ''
+])
+
+const transitionName = computed(() => isRight.value ? 'toast-slide-right' : 'toast-slide-left')
+
+const typeIcon: Record<ToastType, string> = {
+    default: 'Bell',
+    success: 'CircleCheck',
+    error: 'CircleX',
+    warning: 'AlertTriangle',
+    info: 'InfoCircle'
+}
+
+const typeIconColor: Record<ToastType, string> = {
+    default: 'text-gray-500 dark:text-gray-400',
+    success: 'text-green-600 dark:text-green-400',
+    error: 'text-red-600 dark:text-red-400',
+    warning: 'text-amber-500 dark:text-amber-400',
+    info: 'text-blue-600 dark:text-blue-400'
+}
+
+const typeBorder: Record<ToastType, string> = {
+    default: 'border-gray-200 dark:border-gray-700',
+    success: 'border-green-200 dark:border-green-800',
+    error: 'border-red-200 dark:border-red-800',
+    warning: 'border-amber-200 dark:border-amber-700',
+    info: 'border-blue-200 dark:border-blue-800'
+}
+
+const typeBg: Record<ToastType, string> = {
+    default: 'bg-gray-50 dark:bg-gray-900',
+    success: 'bg-green-50 dark:bg-green-950',
+    error: 'bg-red-50 dark:bg-red-950',
+    warning: 'bg-amber-50 dark:bg-amber-950',
+    info: 'bg-blue-50 dark:bg-blue-950'
+}
+
+// Screen reader announcements — cleared after a tick so identical messages re-trigger
+const politeMsg = ref('')
+const assertiveMsg = ref('')
+
+watch(() => toasts.length, (newLen, oldLen) => {
+    if (newLen > oldLen) {
+        const newest = toasts[newLen - 1]
+        if (newest.type === 'error') {
+            assertiveMsg.value = newest.message
+            nextTick(() => { assertiveMsg.value = '' })
+        } else {
+            politeMsg.value = newest.message
+            nextTick(() => { politeMsg.value = '' })
+        }
+    }
+})
+</script>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -2,6 +2,7 @@
     <Teleport to="#portal-target">
         <div
             aria-label="Notifications"
+            role="region"
             :class="containerClass"
         >
             <!-- sr-only live regions for screen reader announcements -->

--- a/src/composables/useIcons.ts
+++ b/src/composables/useIcons.ts
@@ -1,6 +1,7 @@
 import type { Component } from 'vue'
 import {
     // A
+    IconAlertTriangle as AlertTriangle,
     IconArrowDown as ArrowDown,
     IconArrowLeft as ArrowLeft,
     IconArrowRight as ArrowRight,
@@ -16,6 +17,11 @@ import {
     IconChevronUp as ChevronUp,
     IconChevronsLeft as ChevronsLeft,
     IconChevronsRight as ChevronsRight,
+    IconCircleCheck as CircleCheck,
+    IconCircleX as CircleX,
+
+    // I
+    IconInfoCircle as InfoCircle,
 
     // L
     IconLoader as Loader,
@@ -55,6 +61,7 @@ import {
 
 const availableIcons: Record<string, Component> = {
     // A
+    AlertTriangle,
     ArrowDown,
     ArrowLeft,
     ArrowRight,
@@ -70,6 +77,11 @@ const availableIcons: Record<string, Component> = {
     ChevronUp,
     ChevronsLeft,
     ChevronsRight,
+    CircleCheck,
+    CircleX,
+
+    // I
+    InfoCircle,
 
     // L
     Loader,

--- a/src/composables/useToast.ts
+++ b/src/composables/useToast.ts
@@ -1,0 +1,64 @@
+import { reactive } from 'vue'
+import { generateUuid } from '@Utils/uuid'
+
+export type ToastType = 'default' | 'success' | 'error' | 'warning' | 'info'
+
+export interface ToastOptions {
+    type?: ToastType
+    duration?: number
+    permanent?: boolean
+}
+
+export interface ToastItem {
+    id: string
+    message: string
+    type: ToastType
+    duration: number
+    permanent: boolean
+}
+
+// Singleton — shared across all useToast() callers
+const toasts = reactive<ToastItem[]>([])
+const timers = new Map<string, ReturnType<typeof setTimeout>>()
+
+export function useToast() {
+    const startTimer = (id: string, duration: number): void => {
+        timers.set(id, setTimeout(() => remove(id), duration))
+    }
+
+    const pauseTimer = (id: string): void => {
+        clearTimeout(timers.get(id))
+        timers.delete(id)
+    }
+
+    const resumeTimer = (id: string, duration: number): void => {
+        startTimer(id, duration)
+    }
+
+    const add = (message: string, options?: ToastOptions): string => {
+        const id = generateUuid()
+        const toast: ToastItem = {
+            id,
+            message,
+            type: options?.type ?? 'default',
+            duration: options?.duration ?? 4000,
+            permanent: options?.permanent ?? false
+        }
+        toasts.push(toast)
+        if (!toast.permanent) startTimer(id, toast.duration)
+        return id
+    }
+
+    const remove = (id: string): void => {
+        pauseTimer(id)
+        const idx = toasts.findIndex(t => t.id === id)
+        if (idx !== -1) toasts.splice(idx, 1)
+    }
+
+    const clear = (): void => {
+        toasts.forEach(t => pauseTimer(t.id))
+        toasts.splice(0)
+    }
+
+    return { toasts, add, remove, clear, startTimer, pauseTimer, resumeTimer }
+}

--- a/src/css/core.scss
+++ b/src/css/core.scss
@@ -36,3 +36,46 @@
     transform: translateX(-100%);
     opacity: 0;
 }
+
+/* Toast transitions */
+.toast-slide-right-enter-active,
+.toast-slide-right-leave-active {
+    transition:
+        transform 0.5s ease,
+        opacity 0.5s ease;
+}
+
+.toast-slide-right-enter-from,
+.toast-slide-right-leave-to {
+    transform: translateX(110%);
+    opacity: 0;
+}
+
+.toast-slide-right-move {
+    transition: transform 0.5s ease;
+}
+
+.toast-slide-right-leave-active {
+    position: absolute;
+}
+
+.toast-slide-left-enter-active,
+.toast-slide-left-leave-active {
+    transition:
+        transform 0.5s ease,
+        opacity 0.5s ease;
+}
+
+.toast-slide-left-enter-from,
+.toast-slide-left-leave-to {
+    transform: translateX(-110%);
+    opacity: 0;
+}
+
+.toast-slide-left-move {
+    transition: transform 0.5s ease;
+}
+
+.toast-slide-left-leave-active {
+    position: absolute;
+}

--- a/src/stories/components/Toast.stories.ts
+++ b/src/stories/components/Toast.stories.ts
@@ -1,0 +1,254 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Toast from '@Components/Toast.vue'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
+import { useToast } from '@Composables/useToast'
+import type { ToastType } from '@Composables/useToast'
+
+const placements = ['top-right', 'top-left', 'bottom-right', 'bottom-left'] as const
+const types: ToastType[] = ['default', 'success', 'error', 'warning', 'info']
+
+const meta: Meta<typeof Toast> = {
+    title: 'Components/Toast',
+    component: Toast,
+
+    argTypes: {
+        placement: {
+            control: 'select',
+            options: placements,
+            description: 'Corner of the screen where the toast stack appears.'
+        }
+    },
+
+    args: {
+        placement: 'top-right'
+    },
+
+    render: (args) => ({
+        components: { Toast },
+        setup() {
+            const { add, clear } = useToast()
+            return { args, add, clear }
+        },
+        template: `
+            <div id="portal-target"></div>
+
+            <button @click="add('Your changes have been saved.')">
+                Add toast
+            </button>
+
+            <Toast :placement="args.placement" />
+        `
+    })
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+
+        await userEvent.click(canvas.getByRole('button', { name: /add toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+
+        const dismiss = canvas.getByRole('button', { name: /dismiss notification/i })
+        await userEvent.click(dismiss)
+
+        await waitFor(() => expect(canvas.queryByRole('status')).not.toBeInTheDocument())
+    }
+}
+
+export const AllTypes: Story = {
+    render: () => ({
+        components: { Toast },
+        setup() {
+            const { add, clear } = useToast()
+            return { types, add, clear }
+        },
+        template: `
+            <div id="portal-target"></div>
+
+            <div class="flex flex-col gap-2">
+                <button
+                    v-for="type in types"
+                    :key="type"
+                    class="capitalize"
+                    @click="add(\`This is a \${type} notification.\`, { type })"
+                >
+                    {{ type }}
+                </button>
+            </div>
+
+            <Toast placement="top-right" />
+        `
+    }),
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+
+        for (const type of types) {
+            await userEvent.click(canvas.getByRole('button', { name: new RegExp(type, 'i') }))
+        }
+
+        const statuses = await canvas.findAllByRole('status')
+        const alerts = await canvas.findAllByRole('alert')
+
+        await waitFor(() => {
+            expect(statuses.length + alerts.length).toBe(5)
+        })
+    }
+}
+
+export const TopRight: Story = {
+    args: { placement: 'top-right' },
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+    }
+}
+
+export const TopLeft: Story = {
+    args: { placement: 'top-left' },
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+    }
+}
+
+export const BottomRight: Story = {
+    args: { placement: 'bottom-right' },
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+    }
+}
+
+export const BottomLeft: Story = {
+    args: { placement: 'bottom-left' },
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+    }
+}
+
+export const Permanent: Story = {
+    render: () => ({
+        components: { Toast },
+        setup() {
+            const { add, clear } = useToast()
+            return { add, clear }
+        },
+        template: `
+            <div id="portal-target"></div>
+
+            <button @click="add('This notification will not auto-dismiss.', { permanent: true })">
+                Add permanent toast
+            </button>
+
+            <Toast placement="top-right" />
+        `
+    }),
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add permanent toast/i }))
+
+        const toast = await canvas.findByRole('status')
+        await waitFor(() => expect(toast).toBeVisible())
+
+        // Wait beyond default duration to confirm it has not auto-dismissed
+        await new Promise((r) => setTimeout(r, 5000))
+        await expect(toast).toBeVisible()
+    }
+}
+
+export const StackingDemo: Story = {
+    render: () => ({
+        components: { Toast },
+        setup() {
+            const { add, clear } = useToast()
+
+            const addMany = () => {
+                clear()
+                add('First notification — info', { type: 'info', duration: 30000 })
+                add('Second notification — success', { type: 'success', duration: 30000 })
+                add('Third notification — warning', { type: 'warning', duration: 30000 })
+                add('Fourth notification — error', { type: 'error', duration: 30000 })
+                add('Fifth notification — default', { type: 'default', duration: 30000 })
+                add('Sixth notification — info', { type: 'info', duration: 30000 })
+            }
+
+            return { addMany, clear }
+        },
+        template: `
+            <div id="portal-target"></div>
+
+            <div class="flex gap-2">
+                <button @click="addMany">Add 6 toasts</button>
+                <button @click="clear()">Clear all</button>
+            </div>
+
+            <Toast placement="top-right" />
+        `
+    }),
+    play: async ({ canvasElement }) => {
+        const { clear } = useToast()
+        clear()
+
+        const canvas = within(canvasElement)
+        await userEvent.click(canvas.getByRole('button', { name: /add 6 toasts/i }))
+
+        // Only 5 should be visible
+        await waitFor(async () => {
+            const statuses = canvas.queryAllByRole('status')
+            const alerts = canvas.queryAllByRole('alert')
+            expect(statuses.length + alerts.length).toBe(5)
+        })
+
+        // Overflow indicator should be present
+        const moreText = await canvas.findByText(/1 more notification/i)
+        await expect(moreText).toBeVisible()
+
+        // Expand to show all
+        await userEvent.click(canvas.getByRole('button', { name: /show all/i }))
+
+        await waitFor(async () => {
+            const statuses = canvas.queryAllByRole('status')
+            const alerts = canvas.queryAllByRole('alert')
+            expect(statuses.length + alerts.length).toBe(6)
+        })
+    }
+}

--- a/src/stories/composables/useToast.mdx
+++ b/src/stories/composables/useToast.mdx
@@ -1,0 +1,193 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Composables/useToast" />
+
+# useToast
+
+A singleton composable that manages a global toast notification queue. State lives at the module level, so every call to `useToast()` in your app shares the same list of toasts — no providers, no plugins, no context needed.
+
+It handles:
+
+- Queuing and dismissing toast notifications
+- Auto-dismiss timers with hover pause/resume
+- Permanent (non-dismissing) toasts
+- Screen reader announcements via `aria-live`
+
+---
+
+## ✨ Features
+
+- ✅ Singleton state — call `useToast()` anywhere and it just works
+- ✅ Five toast types: `default`, `success`, `error`, `warning`, `info`
+- ✅ Auto-dismiss with configurable duration (default 4s)
+- ✅ Permanent toasts that stay until manually dismissed
+- ✅ Hover pauses the auto-dismiss timer; mouse-leave restarts it
+- ✅ Programmatic dismiss by id, or clear all at once
+- ✅ Screen reader announcements (polite for most types, assertive for errors)
+
+---
+
+## 🚀 App Setup
+
+Place `<Toast />` once at the root of your application, alongside your `#portal-target` element:
+
+```html
+<!-- App.vue -->
+<template>
+    <main>
+        <!-- your app -->
+    </main>
+
+    <Toast placement="top-right" />
+    <div id="portal-target"></div>
+</template>
+
+<script setup>
+import Toast from 'ocelot-ui/Toast'
+</script>
+```
+
+The `<Toast />` component uses Vue's `<Teleport>` to render into `#portal-target`, keeping it out of your layout flow regardless of where you place it in the template.
+
+---
+
+## 🔧 Usage
+
+### Basic
+
+```js
+import { useToast } from 'ocelot-ui'
+
+const { add } = useToast()
+
+add('Your changes have been saved.')
+```
+
+### With type
+
+```js
+const { add } = useToast()
+
+add('File uploaded successfully.', { type: 'success' })
+add('Something went wrong.', { type: 'error' })
+add('Your session expires soon.', { type: 'warning' })
+add('Three new messages.', { type: 'info' })
+```
+
+### Custom duration
+
+```js
+// Dismiss after 8 seconds
+add('Processing complete.', { type: 'success', duration: 8000 })
+```
+
+### Permanent toast
+
+A permanent toast will never auto-dismiss. The user must click the dismiss button.
+
+```js
+add('You have unsaved changes.', { permanent: true })
+```
+
+### Dismiss by id
+
+`add()` returns the toast's id, which can be used to programmatically remove it later:
+
+```js
+const { add, remove } = useToast()
+
+const id = add('Uploading...', { permanent: true })
+
+// later, when upload completes
+remove(id)
+add('Upload complete.', { type: 'success' })
+```
+
+### Clear all
+
+```js
+const { clear } = useToast()
+
+clear()
+```
+
+---
+
+## 📋 API Reference
+
+### `add(message, options?)`
+
+Adds a new toast to the queue and returns its id.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `message` | `string` | The notification text to display. |
+| `options` | `ToastOptions` | Optional configuration (see below). |
+
+**Returns:** `string` — the toast id.
+
+---
+
+### `remove(id)`
+
+Dismisses a specific toast by its id. Clears any running auto-dismiss timer.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | `string` | The id returned by `add()`. |
+
+---
+
+### `clear()`
+
+Dismisses all toasts immediately and clears all running timers.
+
+---
+
+## 🗂️ Types
+
+### `ToastOptions`
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `type` | `ToastType` | `'default'` | Visual style and icon variant. |
+| `duration` | `number` | `4000` | Auto-dismiss delay in milliseconds. |
+| `permanent` | `boolean` | `false` | If `true`, the toast never auto-dismisses. |
+
+### `ToastType`
+
+```ts
+type ToastType = 'default' | 'success' | 'error' | 'warning' | 'info'
+```
+
+### `ToastItem`
+
+The shape of each toast in the reactive queue:
+
+```ts
+interface ToastItem {
+    id: string
+    message: string
+    type: ToastType
+    duration: number
+    permanent: boolean
+}
+```
+
+---
+
+## `<Toast />` Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `placement` | `'top-right' \| 'top-left' \| 'bottom-right' \| 'bottom-left'` | `'top-right'` | Corner where the toast stack appears. |
+
+---
+
+## ⚠️ Notes
+
+- **Singleton state** — the reactive `toasts` array and `timers` Map live at module scope. All calls to `useToast()` in the same app instance share the same state. This is intentional and requires no setup.
+- **Hover pause** is handled by the `<Toast />` component internally — `pauseTimer` and `resumeTimer` are called on `mouseenter`/`mouseleave`. When the mouse leaves, the timer restarts from the full configured duration (not from where it paused).
+- **Stack overflow** — when more than 5 toasts are queued, a pill indicator appears showing how many are hidden. Clicking "Show all" expands the full list; "Dismiss all" clears the queue entirely.
+- **Error announcements** use `aria-live="assertive"` so screen readers interrupt immediately. All other types use `aria-live="polite"` to announce at the next available moment.
+- Place `<Toast />` once only. Multiple instances will each render their own container against the same reactive state, producing duplicate toasts on screen.


### PR DESCRIPTION
## Summary                                                                                             
                                                                                                         
  - Adds a singleton `useToast` composable — call `add()`, `remove()`, or `clear()` from anywhere in the 
  app; all callers share the same reactive toast queue with no plugin or provider setup required         
  - Adds a `Toast.vue` component to place once at the app root; uses `<Teleport>` to render into         
  `#portal-target` and supports `top-right` (default), `top-left`, `bottom-right`, and `bottom-left`     
  placement                                                                                            
  - Toasts auto-dismiss after 4s by default (configurable via `duration`); timers pause on hover/focus
  and resume on leave; `permanent: true` disables auto-dismiss entirely
  - Five types: `default`, `success`, `error`, `warning`, `info` — each with a distinct icon, light
  tinted background (WCAG AAA contrast), and border
  - Stacks up to 5 toasts; overflow shows a control bar with "N more / Show all / Dismiss all"; expanded
  state is scrollable with the control bar pinned outside the scroll area
  - Full dark mode support; `aria-live` announcements (polite for most types, assertive for errors);
  `role="region"` container; all axe checks pass
  - Registers 4 new Tabler icons: `AlertTriangle`, `CircleCheck`, `CircleX`, `InfoCircle`
  - Adds `toast-slide-right` / `toast-slide-left` named transitions to `core.scss` with FLIP-based stack
  reflow
  - Documented in Storybook with 8 interaction stories and a full composable API reference in MDX
